### PR TITLE
Add Custom Order Statuses: 'ACH In Process' and 'On Hold'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Easily accept ACH Direct Debit payments on your WordPress site with our seamless
 **Tags:** woocommerce, payment gateway, Bytepay  
 **Requires at least:** 6.2  
 **Tested up to:** 6.2  
-**Stable tag:** 1.0.1  
+**Stable tag:** 1.0.2  
 **License:** GPLv3 or later  
 **License URI:** [GPLv3 License](https://www.gnu.org/licenses/gpl-3.0.html)
 
@@ -129,6 +129,10 @@ For any issues or enhancement requests with this plugin, please contact the Byte
 ## Documentation
 
 The official documentation for this plugin is available at: [https://www.bytepay.it/docs/wordpress-plugin](https://www.bytepay.it/docs/wordpress-plugin)
+
+### Version 1.0.2
+
+- **New Order Statuses:** Added `ACH In Process` and `On Hold` to support more accurate tracking of order states.
 
 ### Version 1.0.1
 

--- a/bytepay-payment-gateway.php
+++ b/bytepay-payment-gateway.php
@@ -7,7 +7,7 @@
  * Author URI: https://www.bytepay.it/
  * Text Domain: bytepay-payment-gateway
  * Plugin URI: https://github.com/bytepay-it/bytepay-payment-gateway.git
- * Version: 1.0.1
+ * Version: 1.0.2
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/includes/bytepay-payment-gateway-utils.php
+++ b/includes/bytepay-payment-gateway-utils.php
@@ -64,3 +64,22 @@ function bytepay_activation_check()
 		wp_die(esc_html($environment_warning)); // Escape the output before calling wp_die
 	}
 }
+
+function bytepay_plugin_deactivation() {
+    // Get all orders with custom status
+    $args = [
+        'status' => 'ach-in-process',
+        'limit'  => -1,
+        'return' => 'ids',
+    ];
+
+    $orders = wc_get_orders($args);
+
+    foreach ($orders as $order_id) {
+        $order = wc_get_order($order_id);
+        if ($order && $order->get_status() === 'ach-in-process') {
+            $order->update_status('on-hold', __('This order was updated due to changes in the ACH payment method settings.', 'bytepay-payment-gateway')
+);
+        }
+    }
+}

--- a/includes/class-bytepay-payment-gateway-rest-api.php
+++ b/includes/class-bytepay-payment-gateway-rest-api.php
@@ -93,7 +93,8 @@ class BYTEPAY_PAYMENT_GATEWAY_REST_API
 			$this->logger->error('Pay ID mismatch: ' . $pay_id, array('source' => 'bytepay-payment-gateway'));
 			return new WP_REST_Response(['error' => 'Pay ID mismatch'], 400);
 		}
-        if ($api_order_status == 'completed' && in_array($order->get_status(), ['pending', 'failed'])) {
+
+		if (($api_order_status == 'processing' || $api_order_status == 'completed') && in_array($order->get_status(), ['pending', 'failed'])) {
 			// Get the configured order status from the payment gateway settings
 			$gateway_id = 'bytepay';
 			$payment_gateways = WC()->payment_gateways->payment_gateways();
@@ -115,8 +116,8 @@ class BYTEPAY_PAYMENT_GATEWAY_REST_API
 			$order_status = $order->get_status();
 		}
 
-        // Update order status
-        $updated = $order->update_status($order_status, __('Order status updated via API', 'bytepay-payment-gateway'));
+	    // Update order status
+        $updated = $order->update_status($order_status, __('Order status updated via API.', 'bytepay-payment-gateway'));
 
         // Clear the WooCommerce cart if needed
         if (WC()->cart) {

--- a/includes/class-bytepay-payment-gateway.php
+++ b/includes/class-bytepay-payment-gateway.php
@@ -223,9 +223,10 @@ class BYTEPAY_PAYMENT_GATEWAY extends WC_Payment_Gateway_CC
 				'desc_tip' => true,
 				'id' => 'order_status_select', // Add an ID for targeting
 				'options' => array(
-					// '' => __('Select order status', 'bytepay-payment-gateway'), // Placeholder option
 					'processing' => __('Processing', 'bytepay-payment-gateway'),
 					'completed' => __('Completed', 'bytepay-payment-gateway'),
+					'ach-in-process'  => __('ACH in Process', 'bytepay-payment-gateway'),
+        			'on-hold'         => __('On Hold', 'bytepay-payment-gateway'),
 				),
 			),
 			'show_consent_checkbox' => array(

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Bytepay
 Tags: woocommerce, payment gateway, Bytepay
 Requires at least: 5.0
 Tested up to: 6.7
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -27,6 +27,11 @@ Visit the Bytepay website and log in to your account. Navigate to Developer Sett
 
 == Changelog ==
 
+== Changelog ==
+
+= 1.0.2 =
+* New Order Statuses: Added `ACH In Process` and `On Hold` to support more accurate tracking of order states.
+
 = 1.0.1 =
 * Implemented unique payment token handling for orders to prevent duplicate payment processing and enhance order reliability.
 * Resolved blank screen issue and special characters validation issue.
@@ -36,6 +41,11 @@ Visit the Bytepay website and log in to your account. Navigate to Developer Sett
 
 
 == Upgrade Notice ==
+
+== Upgrade Notice ==
+
+= 1.0.2 =
+Adds support for new order statuses `ACH In Process` and `On Hold`. Upgrade recommended for improved order tracking and compatibility with ACH payments.
 
 = 1.0.1 =
 * Implemented unique payment token handling for orders to prevent duplicate payment processing and enhance order reliability.


### PR DESCRIPTION
### Summary
Introduced two new custom WooCommerce order statuses to improve order state tracking:

- **ACH In Process**: For orders awaiting ACH payment processing.
- **On Hold**: For temporary holds or manual review cases.

These statuses provide better visibility into payment stages and allow for more accurate handling in business logic and UI.

### Why This Is Needed
Current statuses do not sufficiently represent ACH workflows or manual intervention states. These additions help distinguish payment flows and pending actions clearly.

### Notes
- Statuses are registered with appropriate labels and icons.
- Ensure any relevant order management logic accounts for the new statuses.
- On **plugin deactivation**, all orders with the `ACH In Process` status will be automatically moved to `On Hold` to prevent them from becoming stuck in a non-standard state.
